### PR TITLE
Reverse expected and actual values in DBDelta

### DIFF
--- a/model.go
+++ b/model.go
@@ -37,7 +37,7 @@ func (m *Model) DBDelta(delta int, name string, fn func()) {
 	fn()
 	ec, err := m.DB.Count(name)
 	m.NoError(err)
-	m.Equal(ec, sc+delta)
+	m.Equal(sc+delta, ec)
 }
 
 func (as *Model) LoadFixture(name string) {


### PR DESCRIPTION
It appears that DBDelta was using the queried final amount, `ec` as the expected value, and the `sc+delta` value as the actual value. As I understand them, they should be reversed for proper display when the test fails.