### PR TITLE
Add actions constructor with plush context

### DIFF
--- a/suite.go
+++ b/suite.go
@@ -39,6 +39,7 @@ func NewActionWithFixtures(app *buffalo.App, box packd.Box) (*Action, error) {
 	return as, nil
 }
 
+// NewActionWithFixturesAndContext returns new Action for given buffalo.App with fixtures and a plush context.
 func NewActionWithFixturesAndContext(app *buffalo.App, box packd.Box, ctx *plush.Context) (*Action, error) {
 	m, err := NewModelWithFixturesAndContext(box, ctx)
 	if err != nil {

--- a/suite.go
+++ b/suite.go
@@ -7,6 +7,7 @@ import (
 	"github.com/gobuffalo/httptest"
 	csrf "github.com/gobuffalo/mw-csrf"
 	"github.com/gobuffalo/packd"
+	"github.com/gobuffalo/plush"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -28,6 +29,18 @@ func NewAction(app *buffalo.App) *Action {
 
 func NewActionWithFixtures(app *buffalo.App, box packd.Box) (*Action, error) {
 	m, err := NewModelWithFixtures(box)
+	if err != nil {
+		return nil, err
+	}
+	as := &Action{
+		App:   app,
+		Model: m,
+	}
+	return as, nil
+}
+
+func NewActionWithFixturesAndContext(app *buffalo.App, box packd.Box, ctx *plush.Context) (*Action, error) {
+	m, err := NewModelWithFixturesAndContext(box, ctx)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
[Feature Request with workaround]

In models.go, there is an additional constructor, `NewModelWithFixturesAndContext` which lets a user access named items from their test fixtures.  This is convenient as users often want to refer to specific named items in the test code as well as in other places in the toml.  However, when using an actions suite there is no constructor available to add a plush context.

This is just a nice to have, it can be worked around by building your own actions suite as shown, however I think it belongs with the other constructors.

```
        ctx := plush.NewContext()
	m, err := suite.NewModelWithFixturesAndContext(packr.New("fixtures", "../fixtures"), ctx)
	if err != nil {
		t.Fatal(err)
	}

	as := &suite.Action{
		App:   App(),
		Model: m,
	}

	suite.Run(t, as)
```