### PR TITLE
Task postgres delete

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        go-version: [1.13.x, 1.14.x]
+        go-version: [1.15.x, 1.16.x]
         os: [macos-latest, windows-latest, ubuntu-latest]
     steps:
     - name: Checkout Code


### PR DESCRIPTION
This PR changes the way we clear Postgres databases to use DELETE instead of using TRUNCATE.

Related to #32.